### PR TITLE
chore: Release programs v0.2.3

### DIFF
--- a/programs/Cargo.lock
+++ b/programs/Cargo.lock
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-blober"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anchor-lang",
  "bincode",
@@ -1575,7 +1575,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-data-correctness-verifier"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anchor-lang",
  "data-anchor-blober",
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-pob-sla-verifier"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anchor-lang",
  "bincode",

--- a/programs/Cargo.toml
+++ b/programs/Cargo.toml
@@ -3,7 +3,7 @@ members = ["programs/blober", "programs/data-correctness", "programs/pob-sla"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "GPL-3.0"
 authors = ["Nitro Labs <team@nitro.technology>"]
@@ -32,7 +32,7 @@ anchor-lang = "=0.31.1"
 sp1-solana = "=0.1.0"
 
 # Locals
-data-anchor-blober = { path = "./programs/blober", version = "0.2.2", default-features = false }
+data-anchor-blober = { path = "./programs/blober", version = "0.2.3", default-features = false }
 
 [profile.release]
 overflow-checks = true

--- a/programs/programs/blober/CHANGELOG.md
+++ b/programs/programs/blober/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/nitro-svm/data-anchor/compare/data-anchor-blober-v0.2.2...data-anchor-blober-v0.2.3) - 2026-02-05
+
+### Other
+
+- Change repo link ([#18](https://github.com/nitro-svm/data-anchor/pull/18))
+- Update package metadata for publishing ([#15](https://github.com/nitro-svm/data-anchor/pull/15))
+
 ## [0.2.2](https://github.com/nitro-svm/data-anchor/compare/data-anchor-blober-v0.2.1...data-anchor-blober-v0.2.2) - 2025-09-23
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `data-anchor-blober`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `data-anchor-data-correctness-verifier`: 0.2.2 -> 0.2.3
* `data-anchor-pob-sla-verifier`: 0.2.2 -> 0.2.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `data-anchor-blober`

<blockquote>

## [0.2.3](https://github.com/nitro-svm/data-anchor/compare/data-anchor-blober-v0.2.2...data-anchor-blober-v0.2.3) - 2026-02-05

### Other

- Change repo link ([#18](https://github.com/nitro-svm/data-anchor/pull/18))
- Update package metadata for publishing ([#15](https://github.com/nitro-svm/data-anchor/pull/15))
</blockquote>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).