### PR TITLE
chore: release v0.4.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2742,7 +2742,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anchor-lang",
  "bytesize",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-api"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anchor-lang",
  "chrono",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-client"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anchor-lang",
  "arbitrary",
@@ -2841,7 +2841,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-data-correctness"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "data-anchor-prover-core",
  "sp1-zkvm 5.2.1",
@@ -2857,7 +2857,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-encoding-compression-test"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "data-anchor-prover-core",
  "data-anchor-utils",
@@ -2866,7 +2866,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-pob-sla"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "data-anchor-prover-core",
  "sp1-zkvm 5.2.1",
@@ -2883,7 +2883,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-proofs"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anchor-lang",
  "arbitrary",
@@ -2904,7 +2904,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-prover"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "data-anchor-api",
  "data-anchor-proofs",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-prover-core"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "data-anchor-proofs",
  "sp1-derive",
@@ -2928,7 +2928,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-prover-script"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anchor-lang",
  "arbitrary",
@@ -2945,7 +2945,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-utils"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["programs", "examples"]
 
 [workspace.package]
 edition = "2024"
-version = "0.4.5"
+version = "0.4.6"
 license = "MIT"
 authors = ["Nitro Labs <team@nitro.technology>"]
 homepage = "https://www.termina.technology"
@@ -89,10 +89,10 @@ sp1-zkvm = "5.2.1"
 nitro-sender = "0.2.0"
 
 # Locals
-data-anchor = { path = "crates/cli", version = "0.4.5" }
-data-anchor-api = { path = "crates/indexer-api", version = "0.4.5" }
-data-anchor-client = { path = "crates/client", version = "0.4.5" }
-data-anchor-proofs = { path = "crates/proofs", version = "0.4.5" }
+data-anchor = { path = "crates/cli", version = "0.4.6" }
+data-anchor-api = { path = "crates/indexer-api", version = "0.4.6" }
+data-anchor-client = { path = "crates/client", version = "0.4.6" }
+data-anchor-proofs = { path = "crates/proofs", version = "0.4.6" }
 data-anchor-blober = { path = "programs/programs/blober", version = "0.2.2", default-features = false, features = [
   "no-entrypoint",
 ] }
@@ -104,7 +104,7 @@ data-anchor-pob-sla-verifier = { path = "programs/programs/pob-sla", version = "
 ] }
 data-anchor-prover = { path = "crates/prover" }
 data-anchor-prover-core = { path = "crates/prover/programs/core" }
-data-anchor-utils = { path = "crates/utils", version = "0.4.5" }
+data-anchor-utils = { path = "crates/utils", version = "0.4.6" }
 
 [patch.crates-io]
 getrandom_v0_1 = { package = "getrandom", git = "https://github.com/nitro-svm/getrandom", branch = "0.1-zkvm" }

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.6](https://github.com/nitro-svm/data-anchor/compare/data-anchor-v0.4.5...data-anchor-v0.4.6) - 2026-02-05
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.4.4](https://github.com/nitro-svm/data-anchor/compare/data-anchor-v0.4.3...data-anchor-v0.4.4) - 2025-09-30
 
 ### Other

--- a/crates/client/CHANGELOG.md
+++ b/crates/client/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.6](https://github.com/nitro-svm/data-anchor/compare/data-anchor-client-v0.4.4...data-anchor-client-v0.4.6) - 2026-02-05
+
+### Added
+
+- Update account loaded data size limits ([#33](https://github.com/nitro-svm/data-anchor/pull/33))
+
+### Other
+
+- release v0.4.5 ([#34](https://github.com/nitro-svm/data-anchor/pull/34))
+
 ## [0.4.5](https://github.com/nitro-svm/data-anchor/compare/data-anchor-client-v0.4.4...data-anchor-client-v0.4.5) - 2026-02-05
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `data-anchor-proofs`: 0.4.5 -> 0.4.6
* `data-anchor-api`: 0.4.5 -> 0.4.6
* `data-anchor-utils`: 0.4.5 -> 0.4.6
* `data-anchor-client`: 0.4.4 -> 0.4.6
* `data-anchor`: 0.4.5 -> 0.4.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `data-anchor-proofs`

<blockquote>

## [0.4.4](https://github.com/nitro-svm/data-anchor/compare/data-anchor-proofs-v0.4.3...data-anchor-proofs-v0.4.4) - 2025-09-30

### Other

- Change repo link ([#18](https://github.com/nitro-svm/data-anchor/pull/18))
</blockquote>

## `data-anchor-api`

<blockquote>

## [0.4.4](https://github.com/nitro-svm/data-anchor/compare/data-anchor-api-v0.4.3...data-anchor-api-v0.4.4) - 2025-09-30

### Other

- Change repo link ([#18](https://github.com/nitro-svm/data-anchor/pull/18))
</blockquote>

## `data-anchor-utils`

<blockquote>

## [0.4.4](https://github.com/nitro-svm/data-anchor/compare/data-anchor-utils-v0.4.3...data-anchor-utils-v0.4.4) - 2025-09-30

### Other

- Change repo link ([#18](https://github.com/nitro-svm/data-anchor/pull/18))
</blockquote>

## `data-anchor-client`

<blockquote>

## [0.4.6](https://github.com/nitro-svm/data-anchor/compare/data-anchor-client-v0.4.4...data-anchor-client-v0.4.6) - 2026-02-05

### Added

- Update account loaded data size limits ([#33](https://github.com/nitro-svm/data-anchor/pull/33))

### Other

- release v0.4.5 ([#34](https://github.com/nitro-svm/data-anchor/pull/34))
</blockquote>

## `data-anchor`

<blockquote>

## [0.4.6](https://github.com/nitro-svm/data-anchor/compare/data-anchor-v0.4.5...data-anchor-v0.4.6) - 2026-02-05

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).