### PR TITLE
chore: release v0.4.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2790,7 +2790,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-blober"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anchor-lang",
  "bincode",
@@ -2849,7 +2849,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-data-correctness-verifier"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anchor-lang",
  "data-anchor-blober",
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "data-anchor-pob-sla-verifier"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anchor-lang",
  "bincode",


### PR DESCRIPTION



## 🤖 New release

* `data-anchor-client`: 0.4.5 -> 0.4.6
* `data-anchor`: 0.4.5 -> 0.4.6

<details><summary><i><b>Changelog</b></i></summary><p>

## `data-anchor-client`

<blockquote>

## [0.4.6](https://github.com/nitro-svm/data-anchor/compare/data-anchor-client-v0.4.4...data-anchor-client-v0.4.6) - 2026-02-05

### Added

- Update account loaded data size limits ([#33](https://github.com/nitro-svm/data-anchor/pull/33))

### Other

- release v0.4.5 ([#34](https://github.com/nitro-svm/data-anchor/pull/34))
</blockquote>

## `data-anchor`

<blockquote>

## [0.4.6](https://github.com/nitro-svm/data-anchor/compare/data-anchor-v0.4.5...data-anchor-v0.4.6) - 2026-02-05

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).